### PR TITLE
Add options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,7 @@ default['aptly']['gpgdisableverify'] = false
 default['aptly']['downloadsourcepackages'] = false
 default['aptly']['ppadistributorid'] = ""
 default['aptly']['ppacodename'] = ""
+# Not set by default, but will be respected. It was needed to set
+# `--force-yes`, because `apt-get -q -y install aptly=0.9.5`
+# returned 100.
+# default['aptly']['install_options']

--- a/providers/mirror.rb
+++ b/providers/mirror.rb
@@ -53,7 +53,7 @@ action :create do
   end
   filter_args = "-filter '#{new_resource.filter}'" if new_resource.filter
   execute "Creating mirror - #{new_resource.name}" do
-    command "aptly mirror create #{filter_args} #{new_resource.name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
+    command "aptly mirror create #{filter_args} #{new_resource.options} #{new_resource.name} #{new_resource.uri} #{new_resource.distribution} #{new_resource.component}"
     user node['aptly']['user']
     group node['aptly']['group']
     environment aptly_env

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -35,7 +35,9 @@ apt_repository "aptly" do
   retry_delay 10
 end
 
-package "aptly"
+package "aptly" do
+  options node['aptly']['install_options'] if node['aptly']['install_options']
+end
 package "graphviz"
 
 group node['aptly']['group'] do

--- a/resources/mirror.rb
+++ b/resources/mirror.rb
@@ -34,3 +34,4 @@ attribute :keyid, :kind_of => String, :default => nil
 attribute :keyserver, :kind_of => String, :default => nil
 attribute :keyfile, :kind_of => String, :default => nil
 attribute :filter, :kind_of => String, :default => nil
+attribute :options, :kind_of => String, :default => nil


### PR DESCRIPTION
I had 2 problems when using `maintenance` branch:
- `apt-get -q -y install aptly=0.9.5` returned exit status: 100. This command installed it without error: `apt-get -q -y install aptly=0.9.5 --force-yes`, so I added attribute `node['aptly']['install_options']` which is not set by default, so the default behavior is not changed.
- using the aptly_mirror resource to create a mirror of docker repositories resulted in e.g. `ERROR: unable to fetch mirror: component main not available in repo [docker-ubuntu-trusty]: https://apt.dockerproject.org/repo/ ubuntu-trusty, use -force-components to override`. The command which worked was `aptly mirror create -force-components  docker-ubuntu-trusty https://apt.dockerproject.org/repo/ ubuntu-trusty main`, so I modified aptly_mirror to respect options so that `-force-components` can be set. Again, it is not set by default, so the default behavior is not changed.
